### PR TITLE
feat(parser): 新增公众号文章封面图解析能力

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -19,6 +19,10 @@ class WeixinParser:
             dict: 解析后的结构化数据
         """
         soup = BeautifulSoup(html, 'html.parser')
+
+        # 提取封面图（og:image，在 <head> 的<meta> 标签中）
+        og_image = soup.find('meta', property='og:image')
+        cover_url = og_image.get('content', '') if og_image else ''
         
         # 提取标题
         title_elem = soup.find('h1', {'id': 'activity-name'})
@@ -41,7 +45,8 @@ class WeixinParser:
             "title": title,
             "author": author,
             "publish_time": publish_time,
-            "content": content
+            "content": content,
+            "cover_url": cover_url
         }
     
     def _clean_content(self, content_elem) -> str:


### PR DESCRIPTION
## 变更说明

本次更新在文章解析流程中新增了封面图提取能力：

- 从文章 HTML 的 `meta[property="og:image"]` 中提取封面图 URL
- 在解析结果中新增 `cover_url` 字段
- 当页面不存在 `og:image` 时，`cover_url` 返回空字符串，保证兼容性

## 修改文件

- `src/parser.py`

## 兼容性说明

- 现有字段（`title`、`author`、`publish_time`、`content`）保持不变
- 新增字段为增量能力，不影响已有调用逻辑

## 使用场景

上层调用方（如 MCP 客户端/大模型）可直接使用 `cover_url` 获取文章封面图，用于摘要展示、卡片渲染等场景。
