### PR TITLE
v0.2.0: 换 agent-browser 做反爬内核 (fixes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,36 @@
 
 - **Python 3.10+**
 - **fastmcp** - MCP框架
-- **Playwright** - 浏览器自动化
+- **agent-browser** (Rust + Chrome for Testing + 裸 CDP) - 反爬抓取内核,外部二进制依赖
 - **BeautifulSoup4** - HTML解析
+
+> **v0.2.0 升级说明**: 原 Playwright 方案被微信加强反爬打穿 ([issue #3](https://github.com/Bwkyd/wexin-read-mcp/issues/3))。抓取层改为委托给 [agent-browser](https://github.com/vercel-labs/agent-browser)(Apache-2.0 开源 Rust 项目),反爬内核由上游维护升级。MCP 协议/接口零变化,现有 Claude/Cursor 配置不需要调整。
 
 ## 快速开始
 
-### 1. 安装依赖
+### 1. 安装 agent-browser (反爬内核,v0.2.0 起必需)
 
-# 安装Python依赖
+```bash
+# 推荐: Homebrew (macOS)
+brew install agent-browser
+
+# 或: npm 全局安装
+npm install -g agent-browser
+
+# 验证
+agent-browser --version
+
+# 首次运行会自动下载 Chrome for Testing (~150 MB),按提示确认即可
+agent-browser install
+```
+
+### 2. 安装 Python 依赖
+
+```bash
 pip install -r requirements.txt
+```
 
-### 2. 配置
+### 3. 配置
 
 ```json
 {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 # Core dependencies
 fastmcp>=0.1.0
-playwright>=1.40.0
 beautifulsoup4>=4.12.0
-lxml>=4.9.0
+
+# v0.2.0+: playwright / lxml 已移除.
+# 抓取层通过 subprocess 调 agent-browser binary, 需要另外安装:
+#   brew install agent-browser
+#   # 或: npm install -g agent-browser
 
 # Development dependencies (optional)
 # pytest>=7.4.0
 # pytest-asyncio>=0.21.0
-

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -1,6 +1,17 @@
-"""Playwright浏览器爬虫"""
+"""微信文章爬虫 - 委托 agent-browser (Rust + CDP + Chrome for Testing) 做反爬.
 
-from playwright.async_api import async_playwright, Browser, BrowserContext
+v0.2.0 起,原 Playwright 方案被微信加强反爬打穿(issue #3).
+抓取层改为 subprocess 调用 agent-browser binary, 反爬内核由上游 Rust 项目维护.
+
+前置要求: agent-browser 已装在 PATH 中
+  brew install agent-browser
+  # 或 npm install -g agent-browser
+"""
+
+import asyncio
+import json
+import shutil
+import uuid
 
 # 支持相对导入和绝对导入
 try:
@@ -9,80 +20,146 @@ except ImportError:
     from parser import WeixinParser
 
 
+class AgentBrowserNotFound(RuntimeError):
+    """agent-browser binary 未在 PATH 中."""
+
+
 class WeixinScraper:
-    """微信文章爬虫"""
-    
+    """微信文章爬虫 - 通过 agent-browser binary 抓取."""
+
     def __init__(self):
         self.parser = WeixinParser()
-        self.playwright = None
-        self.browser: Browser | None = None
-        self.context: BrowserContext | None = None
-    
+        # 每个 WeixinScraper 实例独占一个 session 名
+        self._session_name = f"weixin-mcp-{uuid.uuid4().hex[:8]}"
+        self._session_active = False
+        # MCP server 通常把 WeixinScraper 做全局单例,并发请求共享同一 session.
+        # 同一 session 的两次 navigate 会冲突(后者把前者的 page 覆盖),故串行化.
+        self._lock = asyncio.Lock()
+
     async def initialize(self):
-        """初始化浏览器"""
-        if not self.browser:
-            self.playwright = await async_playwright().start()
-            self.browser = await self.playwright.chromium.launch(
-                headless=True,
-                args=[
-                    '--disable-blink-features=AutomationControlled',
-                ]
+        """验证 agent-browser 可用, 首次调用显式报错比抓取时报错更友好."""
+        if not shutil.which("agent-browser"):
+            raise AgentBrowserNotFound(
+                "agent-browser binary not found in PATH.\n"
+                "Install:\n"
+                "  brew install agent-browser\n"
+                "  # or: npm install -g agent-browser\n"
+                "See: https://github.com/vercel-labs/agent-browser"
             )
-            self.context = await self.browser.new_context(
-                viewport={'width': 1920, 'height': 1080},
-                user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-            )
-    
+
     async def fetch_article(self, url: str) -> dict:
-        """
-        获取微信文章内容
-        
+        """获取微信文章内容.
+
         Args:
             url: 文章URL
-            
+
         Returns:
-            dict: 包含文章数据的字典
+            dict: {success, title, author, publish_time, content, cover_url, error}
         """
-        try:
-            await self.initialize()
-            
-            # 创建新页面
-            page = await self.context.new_page()
-            
+        async with self._lock:
             try:
-                # 访问URL，等待网络空闲
-                await page.goto(url, wait_until='networkidle', timeout=30000)
-                
-                # 等待关键元素加载
-                await page.wait_for_selector('#js_content', timeout=10000)
-                
-                # 获取页面HTML
-                html_content = await page.content()
-                
-                # 解析内容
-                result = self.parser.parse(html_content, url)
-                
+                await self.initialize()
+
+                # 1. open URL (agent-browser 会自动启动/复用 session daemon)
+                open_result = await self._run(
+                    ["--session", self._session_name, "open", url, "--json"],
+                    timeout=30,
+                )
+                if not open_result.get("success", False):
+                    return {
+                        "success": False,
+                        "error": f"open failed: {open_result.get('error', 'unknown')}",
+                    }
+                self._session_active = True
+
+                # 2. 等待微信正文容器渲染.等不到即反爬拦截页(无 #js_content),早停.
+                wait_result = await self._run(
+                    ["--session", self._session_name, "wait", "#js_content", "--json"],
+                    timeout=15,
+                )
+                if not wait_result.get("success", False):
+                    return {
+                        "success": False,
+                        "error": (
+                            "wait for #js_content failed — likely anti-bot "
+                            "interception page. detail: "
+                            f"{wait_result.get('error', 'timeout')}"
+                        ),
+                    }
+
+                # 3. 取整页 HTML (<html> 元素的 innerHTML)
+                html_result = await self._run(
+                    ["--session", self._session_name, "get", "html", "html", "--json"],
+                    timeout=10,
+                )
+                if not html_result.get("success", False):
+                    return {
+                        "success": False,
+                        "error": f"get html failed: {html_result.get('error')}",
+                    }
+                html = (
+                    html_result.get("data", {}).get("html")
+                    or html_result.get("html")
+                    or ""
+                )
+                if not html:
+                    return {"success": False, "error": "empty HTML response"}
+
+                # 4. 解析 (复用原 parser.py, 保留 cover_url 等字段)
+                parsed = self.parser.parse(html, url)
+                return {"success": True, **parsed, "error": None}
+
+            except AgentBrowserNotFound as e:
+                return {"success": False, "error": str(e)}
+            except asyncio.TimeoutError:
+                return {"success": False, "error": "agent-browser subprocess timeout"}
+            except Exception as e:
                 return {
-                    "success": True,
-                    **result,
-                    "error": None
+                    "success": False,
+                    "error": f"Failed to fetch article: {type(e).__name__}: {e}",
                 }
-            finally:
-                # 确保页面关闭
-                await page.close()
-                
-        except Exception as e:
+
+    async def cleanup(self):
+        """关闭 session, 释放 agent-browser 对应的 daemon 进程."""
+        if self._session_active:
+            try:
+                await self._run(
+                    ["--session", self._session_name, "close"],
+                    timeout=5,
+                )
+            except Exception:
+                pass  # cleanup 失败不阻塞退出
+            self._session_active = False
+
+    async def _run(self, args: list, timeout: int) -> dict:
+        """执行一次 agent-browser 子进程, 返回解析后的 JSON dict."""
+        proc = await asyncio.create_subprocess_exec(
+            "agent-browser",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
+
+        if proc.returncode != 0:
             return {
                 "success": False,
-                "error": f"Failed to fetch article: {str(e)}"
+                "error": stderr.decode(errors="replace").strip()
+                or f"exit code {proc.returncode}",
             }
-    
-    async def cleanup(self):
-        """清理资源"""
-        if self.context:
-            await self.context.close()
-        if self.browser:
-            await self.browser.close()
-        if self.playwright:
-            await self.playwright.stop()
 
+        raw = stdout.decode(errors="replace").strip()
+        if not raw:
+            return {"success": True, "data": {}}
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            # 某些子命令可能返回纯文本, 封装成统一 shape
+            return {"success": True, "data": {"raw": raw}}


### PR DESCRIPTION
## Summary

- 微信加强反爬后,Playwright 方案被完全打穿(issue #3 "died?")。本 PR 把抓取层换成 subprocess 调 **agent-browser** (Apache-2.0, Rust + Chrome for Testing + 裸 CDP),反爬内核由上游开源项目维护升级。
- MCP 工具签名 (`read_weixin_article`) 与 Claude/Cursor 配置**零变化**,现有用户升级只需一次性装 `agent-browser` binary。
- Closes #3

## Changes

| 文件 | 动作 |
|---|---|
| `src/scraper.py` | 重写为 subprocess 调 agent-browser;保留 `WeixinScraper` 类 API / 方法签名 / 返回字典字段;加 `asyncio.Lock` 防并发 session 冲突;wait 失败早停避免吃反爬拦截页的垃圾 HTML |
| `requirements.txt` | 移除 \`playwright\` + \`lxml\`;新增外部依赖说明 |
| `README.md` | 加 \"前置要求: 装 agent-browser\" 章节与迁移指引 |
| `src/server.py` / `src/parser.py` | **零改动** |

## Breaking change (migration guide)

现有用户升级到 v0.2.0:

\`\`\`bash
# 1. 装 agent-browser (一次性)
brew install agent-browser          # 或: npm install -g agent-browser

# 2. 首次运行下载 Chrome for Testing
agent-browser install

# 3. 更新本仓库 + Python 依赖
git pull && pip install -r requirements.txt
# (可选) 卸载不再需要的 playwright: pip uninstall playwright
\`\`\`

MCP 客户端配置(Claude Desktop / Cursor)**完全不用改**。

## Test plan

- [x] **Good path** - 抓取 issue #3 里 Playwright 失效的微信 URL (\`mp.weixin.qq.com/s/AMJBh90iNEZBRLY3iWsYxQ\`) → success=True, title/author/publish_time/content (8935 字节) / cover_url 全部正确
- [x] **Concurrent path** - 两个并发 \`fetch_article\` 请求 → 都 success (asyncio.Lock 生效)
- [x] **Bad path** - 无效 URL → 返回明确 error,不再吃反爬拦截页的垃圾数据
- [ ] Claude Desktop 实际场景测试 (留给 merge 后)

## 后续 (v0.3.0+ 规划)

- 与 Rust 新项目 [\`url-md\`](https://github.com/Bwkyd/url-md) 协同:通用 URL → Markdown,覆盖微信之外的站点 (知乎/Substack/博客...)。\`wexin-read-mcp\` 继续保留为微信专用 MCP 入口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)